### PR TITLE
Fix Calculator Time Period and UPI Link Intents

### DIFF
--- a/views/calculator.ejs
+++ b/views/calculator.ejs
@@ -26,8 +26,13 @@
                     </div>
 
                     <div class="mb-3">
-                        <label for="calcTime" class="form-label">Time Period (Years)</label>
-                        <input type="number" step="0.01" class="form-control" id="calcTime" required>
+                        <label for="startDate" class="form-label">Start Date</label>
+                        <input type="date" class="form-control" id="startDate" required>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="endDate" class="form-label">End Date</label>
+                        <input type="date" class="form-control" id="endDate" required>
                     </div>
 
                     <div class="mb-3">
@@ -44,6 +49,7 @@
 
                 <div id="calcResult" class="mt-4 alert alert-info" style="display: none;">
                     <h5>Results</h5>
+                    <p>Total Time Period: <span id="resTimePeriod">0</span></p>
                     <p>Total Interest: <span id="resInterest">0</span></p>
                     <p>Total Amount (Principal + Interest): <span id="resTotal">0</span></p>
                 </div>
@@ -55,13 +61,26 @@
         function calculateInterest() {
             const p = parseFloat(document.getElementById('calcAmount').value);
             const r = parseFloat(document.getElementById('calcRate').value);
-            const t = parseFloat(document.getElementById('calcTime').value);
+            const startDateStr = document.getElementById('startDate').value;
+            const endDateStr = document.getElementById('endDate').value;
             const type = document.getElementById('calcType').value;
 
-            if (isNaN(p) || isNaN(r) || isNaN(t)) {
-                alert("Please enter valid numbers");
+            if (isNaN(p) || isNaN(r) || !startDateStr || !endDateStr) {
+                alert("Please enter valid numbers and dates");
                 return;
             }
+
+            const startDate = new Date(startDateStr);
+            const endDate = new Date(endDateStr);
+
+            if (endDate < startDate) {
+                alert("End date cannot be before start date");
+                return;
+            }
+
+            const timeDiff = Math.abs(endDate.getTime() - startDate.getTime());
+            const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
+            const t = daysDiff / 365;
 
             let interest = 0;
             let total = 0;
@@ -74,6 +93,7 @@
                 interest = total - p;
             }
 
+            document.getElementById('resTimePeriod').innerText = `${daysDiff} days (${t.toFixed(2)} years)`;
             document.getElementById('resInterest').innerText = interest.toFixed(2);
             document.getElementById('resTotal').innerText = total.toFixed(2);
             document.getElementById('calcResult').style.display = 'block';

--- a/views/loans/index.ejs
+++ b/views/loans/index.ejs
@@ -56,10 +56,12 @@
                                             <%
                                             // Ideally, populate target user to get their UPI ID,
                                             // Assuming the target user is populated in borrower
-                                            let upiId = req.borrower && req.borrower.upiId ? req.borrower.upiId : 'placeholder@upi';
-                                            let name = req.borrower && req.borrower.username ? req.borrower.username : 'User';
+                                            let rawUpiId = req.borrower && req.borrower.upiId ? req.borrower.upiId : 'placeholder@upi';
+                                            let rawName = req.borrower && req.borrower.username ? req.borrower.username : 'User';
+                                            let upiId = encodeURIComponent(rawUpiId);
+                                            let name = encodeURIComponent(rawName);
                                             %>
-                                            <a href="upi://pay?pa=<%= upiId %>&pn=<%= name %>&am=<%= req.amount %>&cu=INR" class="btn btn-sm btn-info text-white">Accept & Pay via UPI</a>
+                                            <a href="upi://pay?pa=<%= upiId %>&pn=<%= name %>&am=<%= req.amount %>&cu=INR&tn=Loan%20Request" class="btn btn-sm btn-info text-white">Accept & Pay via UPI</a>
                                         <% } %>
                                     </div>
                                 </li>
@@ -110,10 +112,12 @@
                                         <button class="btn btn-sm btn-outline-danger">Mark Settled</button>
                                     </form>
                                     <%
-                                    let upiId = loan.lender && loan.lender.upiId ? loan.lender.upiId : 'placeholder@upi';
-                                    let name = loan.lender && loan.lender.username ? loan.lender.username : 'Lender';
+                                    let rawUpiId = loan.lender && loan.lender.upiId ? loan.lender.upiId : 'placeholder@upi';
+                                    let rawName = loan.lender && loan.lender.username ? loan.lender.username : 'Lender';
+                                    let upiId = encodeURIComponent(rawUpiId);
+                                    let name = encodeURIComponent(rawName);
                                     %>
-                                    <a href="upi://pay?pa=<%= upiId %>&pn=<%= name %>&am=<%= loan.amount %>&cu=INR" class="btn btn-sm btn-info text-white mt-2">Pay via UPI</a>
+                                    <a href="upi://pay?pa=<%= upiId %>&pn=<%= name %>&am=<%= loan.amount %>&cu=INR&tn=Loan%20Repayment" class="btn btn-sm btn-info text-white mt-2">Pay via UPI</a>
                                 </li>
                             <% }) %>
                         <% } %>


### PR DESCRIPTION
Fixes the interest calculator to use date pickers instead of numbers for time periods and fixes an issue where the UPI app would not open because of unencoded spaces in the url.

---
*PR created automatically by Jules for task [16518944747430008331](https://jules.google.com/task/16518944747430008331) started by @therajesh8769*