### PR TITLE
Fix mobile page scrolling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -125,7 +125,7 @@ body {
 }
 
 .footer {
-    position: fixed;
+    position: relative;
     bottom: 0;
     left: 0;
     height: 100px;
@@ -167,7 +167,7 @@ body {
     align-items: center;
     padding: 20px;
     justify-content: center;
-    min-height: 100vh;
+    min-height: calc(100vh - 100px);
 }
 .money_input
 {


### PR DESCRIPTION
Fixed the mobile view of the home page so it is visible and scrollable. Previously, the footer was positioned fixed to the bottom and would overlap the main content when it overflowed the viewport height. Changed the footer position to relative and adjusted the min-height of the main content container to account for the footer height. This ensures the footer remains at the end of the content and the page can scroll normally.

---
*PR created automatically by Jules for task [3469652623758501822](https://jules.google.com/task/3469652623758501822) started by @therajesh8769*